### PR TITLE
Add checkpointing to training loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # abstractinator
+
+The training script now supports periodic checkpointing. Configure the
+`checkpoint_interval` and `checkpoint_dir` fields in `train.py`'s
+`exp_config` to control how often checkpoints are saved and where they are
+stored. Set `resume_from_checkpoint` to the path of a saved checkpoint to
+resume training from that point.


### PR DESCRIPTION
## Summary
- checkpoint training state periodically and allow resuming
- document new checkpoint options in README

## Testing
- `python -m py_compile train.py components/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68484fb7925c8326bb5511a08c8074ca