### PR TITLE
Move configuration to separate file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # abstractinator
 
-The training script now supports periodic checkpointing. Configure the
-`checkpoint_interval` and `checkpoint_dir` fields in `train.py`'s
-`exp_config` to control how often checkpoints are saved and where they are
-stored. Set `resume_from_checkpoint` to the path of a saved checkpoint to
-resume training from that point.
+The training script now supports periodic checkpointing. Configuration
+options have been moved to `config.py`.  Edit the
+`checkpoint_interval` and `checkpoint_dir` fields in `config.py`'s
+`exp_config` dictionary to control how often checkpoints are saved and
+where they are stored. Set `resume_from_checkpoint` to the path of a
+saved checkpoint to resume training from that point.

--- a/config.py
+++ b/config.py
@@ -1,0 +1,65 @@
+import os
+import torch
+
+# Determine CPU count for data loading and processing
+N_CPU = int(os.cpu_count()) if os.cpu_count() else 1  # Ensure at least one worker
+
+# Determine the preferred device
+DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
+if torch.backends.mps.is_available() and DEVICE == "cpu":
+    DEVICE = torch.device("mps")
+
+# Experiment configuration dictionary
+exp_config = {
+    "run_name": "HierarchicalAE_KPM_Run_v2",
+    "project_name": "TemporalAutoencodedLanguageModelling",
+    "num_levels": 1,
+    "initial_vocab_size": 259,
+    "compressor_level_configs": [
+        {"dim": 768, "heads": 12, "window": 512,
+         "num_encoder_layers": 14,
+         'encoder_ffn_dim_multiplier': 4,
+         'encoder_dropout': 0.1,
+         'max_seq_len_encoder': 4096,
+         "num_queries": 1,
+         "pooler_dropout": 0.1,
+         "codebook_size": 49404,
+         "beta": 1.0},
+    ],
+    "expander_dim_scale": 1.0,
+    "expander_num_enc_layers": 6,
+    "expander_num_dec_layers": 6,
+    "expander_heads_scale": 1.0,
+    "expander_dropout": 0.1,
+    "expander_eos_id": 1,
+    "expander_max_len": 2048,
+    "propagate_key_padding_mask": True,
+    "aux_lm_loss_weight": 1.0,
+    "top_lm_loss_weight": 0.2,
+    # "top_transformer_config": {
+    #     "dim": 768,
+    #     "num_layers": 16,
+    #     "num_heads": 12,
+    #     "ffn_dim_multiplier": 4,
+    #     "dropout": 0.1,
+    #     "max_seq_len": 2048,
+    #     "output_lm_logits": True
+    # },
+    "learning_rate": 1e-4,
+    "batch_size": 4,
+    "sequence_length": 1024,
+    "num_epochs": 10,
+    "log_interval": 1,
+    "gradient_clip_norm": 1.0,
+    "gradient_accumulation_steps": 32,
+    "dataset_name": "HuggingFaceFW/fineweb-edu",
+    "dataset_config": "sample-10BT",
+    "dataset_train_split": "train",
+    "text_column_name": "text",
+    "generation_interval": 50,
+    "sample_prompt_for_generation": "The purpose of education is ",
+    "generation_max_len_override": 512,
+    "checkpoint_interval": 1000,
+    "checkpoint_dir": "./checkpoints",
+    "resume_from_checkpoint": None,
+}


### PR DESCRIPTION
## Summary
- centralize run configuration in `config.py`
- load `DEVICE`, `N_CPU` and `exp_config` from the new module
- update documentation to reference `config.py`

## Testing
- `python -m py_compile train.py config.py components/*.py`

------
https://chatgpt.com/codex/tasks/task_e_684853eaff9083268ea67a27d5948989