### PR TITLE
Remove unused batched import

### DIFF
--- a/train.py
+++ b/train.py
@@ -3,7 +3,6 @@ import math
 import sys
 import time
 from collections import defaultdict
-from itertools import batched
 
 import torch
 from datasets import load_dataset, Dataset  # Import Dataset for the dummy data


### PR DESCRIPTION
## Summary
- remove an unused import of `batched` from `train.py`
- confirm only remaining reference is to the `batched` parameter of `raw_dataset.map`

## Testing
- `grep -R "batched" -n --exclude-dir=.git`

------
https://chatgpt.com/codex/tasks/task_e_685187209f7883268195e299c3d953b7