### PR TITLE
Fix perplexity without EMA

### DIFF
--- a/components/vector_quantizer.py
+++ b/components/vector_quantizer.py
@@ -154,7 +154,10 @@ class VectorQuantizer(nn.Module):
                     self._reset_dead_codes()
                     self.steps_since_last_reset.zero_()
 
-        counts = self.ema_cluster_size.clamp(min=self.eps)
+        if self.ema:
+            counts = self.ema_cluster_size.clamp(min=self.eps)
+        else:
+            counts = torch.bincount(indices, minlength=self.K).float().clamp(min=self.eps)
         probs = counts / (counts.sum() + self.eps)
         entropy = -(probs.double() * probs.double().log()).sum()
         perplexity = entropy.exp().float()

--- a/tests/test_vector_quantizer.py
+++ b/tests/test_vector_quantizer.py
@@ -1,0 +1,21 @@
+import torch
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from components.vector_quantizer import VectorQuantizer
+
+def test_vector_quantizer_forward_no_ema():
+    torch.manual_seed(0)
+    vq = VectorQuantizer(K=8, D=4, ema=False)
+    x = torch.randn(2, 3, 4)
+    z_q, vq_loss, indices, perplexity = vq(x)
+    assert z_q.shape == x.shape
+    assert vq_loss.requires_grad
+    assert indices.shape == (2, 3)
+    assert perplexity.dim() == 0
+    counts = torch.bincount(indices.view(-1), minlength=vq.K).float().clamp(min=vq.eps)
+    probs = counts / (counts.sum() + vq.eps)
+    entropy = -(probs.double() * probs.double().log()).sum()
+    expected = entropy.exp().float()
+    assert torch.allclose(perplexity, expected)


### PR DESCRIPTION
## Summary
- handle perplexity calculation when `ema=False`
- add regression test for non-EMA usage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685186f7347c8326ae728c9caf7cd36f