### PR TITLE
Add LLM evaluation harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,22 @@ Key modules under `components/` include:
 - `HierarchicalAutoencoder` – stacks compressors and expanders for end-to-end compression.
 
 See `notes.md` for additional design thoughts.
+
+## Evaluation
+
+Run a suite of standard LLM benchmarks using the evaluation harness:
+
+```bash
+python evaluate.py --model hf --model_args pretrained=facebook/opt-1.3b use_accelerate=True
+```
+
+By default this evaluates on tasks like `lambada_openai`, `hellaswag` and
+`arc_easy`.  Additional tasks or model arguments can be specified via command
+line flags.
+
+To test a model you've trained with `train.py`, point the harness at the saved
+checkpoint using the `hier_ae` model type:
+
+```bash
+python evaluate.py --model hier_ae --model_args checkpoint=./checkpoints/checkpoint_step1000.pt
+```

--- a/components/hae_lm.py
+++ b/components/hae_lm.py
@@ -1,0 +1,100 @@
+from typing import List, Tuple, Optional
+
+import torch
+import torch.nn.functional as F
+from tqdm import tqdm
+
+from lm_eval.api.model import LM
+from lm_eval.api.registry import register_model
+from lm_eval import utils
+
+from config import exp_config, DEVICE
+from train import ByteLevelTokenizer
+from components import HierarchicalAutoencoder
+
+
+@register_model("hier_ae")
+class HierarchicalAELM(LM):
+    """LM-Eval adapter for HierarchicalAutoencoder checkpoints."""
+
+    def __init__(self, checkpoint: str, device: Optional[str] = None) -> None:
+        super().__init__()
+        self.device = device or DEVICE
+        self.tokenizer = ByteLevelTokenizer(add_bos=True, add_eos=True)
+        self.model = HierarchicalAutoencoder(
+            num_levels=exp_config["num_levels"],
+            compressor_level_configs=exp_config["compressor_level_configs"],
+            initial_vocab_size=exp_config["initial_vocab_size"],
+            expander_dim_scale=exp_config["expander_dim_scale"],
+            expander_num_enc_layers=exp_config["expander_num_enc_layers"],
+            expander_num_dec_layers=exp_config["expander_num_dec_layers"],
+            expander_heads_scale=exp_config["expander_heads_scale"],
+            expander_dropout=exp_config["expander_dropout"],
+            expander_eos_id=exp_config["expander_eos_id"],
+            expander_max_len=exp_config["expander_max_len"],
+            propagate_key_padding_mask=exp_config["propagate_key_padding_mask"],
+            aux_lm_loss_weight=exp_config["aux_lm_loss_weight"],
+            top_transformer_config=exp_config.get("top_transformer_config"),
+            top_lm_loss_weight=exp_config.get("top_lm_loss_weight", 0.0),
+        ).to(self.device)
+        ckpt = torch.load(checkpoint, map_location=self.device)
+        self.model.load_state_dict(ckpt["model_state"])
+        self.model.eval()
+
+    @classmethod
+    def create_from_arg_string(cls, arg_string: str, additional_config=None):
+        args = utils.simple_parse_args_string(arg_string)
+        checkpoint = args.get("checkpoint")
+        device = args.get("device")
+        if checkpoint is None:
+            raise ValueError("checkpoint path must be provided")
+        return cls(checkpoint=checkpoint, device=device)
+
+    def tok_encode(self, string: str):
+        return self.tokenizer.encode(string, add_bos=True, add_eos=False).tolist()
+
+    def tok_decode(self, tokens):
+        return self.tokenizer.decode(tokens, cut_at_eos=True)
+
+    @property
+    def max_length(self) -> int:
+        return exp_config.get("expander_max_len", 2048)
+
+    def _tokens_logprobs(self, tokens: torch.Tensor) -> torch.Tensor:
+        with torch.no_grad():
+            out = self.model(tokens)
+            logits = out["final_reconstructed_logits"]
+        log_probs = F.log_softmax(logits, dim=-1)
+        return log_probs
+
+    def loglikelihood(self, requests, disable_tqdm: bool = False) -> List[Tuple[float, bool]]:
+        results = []
+        for context, continuation in tqdm(requests, disable=disable_tqdm):
+            full_text = context + continuation
+            full_tokens = torch.tensor(self.tok_encode(full_text)).unsqueeze(0).to(self.device)
+            context_len = len(self.tok_encode(context))
+            log_probs = self._tokens_logprobs(full_tokens)
+            target_ids = full_tokens[:, 1:]
+            per_token = log_probs[0, :-1].gather(1, target_ids.t().unsqueeze(1)).squeeze(1)
+            cont_ll = per_token[context_len - 1 :].sum().item()
+            results.append((cont_ll, True))
+        return results
+
+    def loglikelihood_rolling(self, requests, disable_tqdm: bool = False) -> List[float]:
+        results = []
+        for (string,) in tqdm(requests, disable=disable_tqdm):
+            tokens = torch.tensor(self.tok_encode(string)).unsqueeze(0).to(self.device)
+            log_probs = self._tokens_logprobs(tokens)
+            target_ids = tokens[:, 1:]
+            per_token = log_probs[0, :-1].gather(1, target_ids.t().unsqueeze(1)).squeeze(1)
+            results.append(per_token.sum().item())
+        return results
+
+    def generate_until(self, requests, disable_tqdm: bool = False):
+        results = []
+        for context, gen_kwargs in tqdm(requests, disable=disable_tqdm):
+            tokens = torch.tensor(self.tok_encode(context)).unsqueeze(0).to(self.device)
+            max_len = gen_kwargs.get("max_gen_toks", 32)
+            out_tokens = self.model.generate_bytes(tokens, max_len_override=max_len)
+            results.append(self.tok_decode(out_tokens.squeeze(0).tolist()))
+        return results

--- a/evaluate.py
+++ b/evaluate.py
@@ -1,0 +1,57 @@
+import argparse
+import json
+
+from lm_eval import evaluator
+import components.hae_lm  # registers HierarchicalAELM with lm_eval
+
+DEFAULT_TASKS = [
+    "lambada_openai",
+    "hellaswag",
+    "piqa",
+    "arc_easy",
+    "arc_challenge",
+    "openbookqa",
+    "winogrande",
+]
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run LLM evaluation tasks")
+    parser.add_argument("--model", default="hf", help="Model type (e.g. hf)")
+    parser.add_argument(
+        "--model_args",
+        default=None,
+        help="Model arguments string passed to the evaluation harness",
+    )
+    parser.add_argument(
+        "--tasks",
+        nargs="+",
+        default=DEFAULT_TASKS,
+        help="Which evaluation tasks to run",
+    )
+    parser.add_argument("--num_fewshot", type=int, default=0, help="Number of few-shot examples")
+    parser.add_argument("--batch_size", type=int, default=None, help="Per-device batch size")
+    parser.add_argument("--device", default=None, help="Device string for PyTorch")
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Limit number of evaluation examples (mainly for quick tests)",
+    )
+    args = parser.parse_args()
+
+    results = evaluator.simple_evaluate(
+        model=args.model,
+        model_args=args.model_args,
+        tasks=args.tasks,
+        num_fewshot=args.num_fewshot,
+        batch_size=args.batch_size,
+        device=args.device,
+        limit=args.limit,
+    )
+
+    print(json.dumps(results, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ torch
 datasets
 aim
 transformers
+lm-eval


### PR DESCRIPTION
## Summary
- add `evaluate.py` that wraps the lm-eval harness
- document running the evaluation
- include `lm-eval` in requirements
- plug evaluation harness into checkpoints with custom `hier_ae` model

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685746271c00832692b4e5ed78a52ca7