### PR TITLE
Switch to RoPE across modules

### DIFF
--- a/components/byte_segment_compressor.py
+++ b/components/byte_segment_compressor.py
@@ -39,7 +39,6 @@ class ByteSegmentCompressor(nn.Module):
                  window: int = 128, # Window size for encoder
                  num_encoder_layers: int = 3,
                  encoder_ffn_dim_multiplier: int = 4,
-                 max_seq_len_encoder: int = 4096, # Max sequence length for encoder's PE
                  num_queries: int = 1, # L: Number of queries per segment for the pooler
                  codebook_size: int = 512,    # K: Number of codes in VQ codebook
                  beta: float = 0.25):          # Beta for VQ commitment loss
@@ -54,8 +53,7 @@ class ByteSegmentCompressor(nn.Module):
             num_heads=heads,
             window_size=window,
             num_layers=num_encoder_layers,
-            ffn_dim_multiplier=encoder_ffn_dim_multiplier,
-            max_seq_len=max_seq_len_encoder
+            ffn_dim_multiplier=encoder_ffn_dim_multiplier
         )
 
         # Initialize the attention pooler that uses learned queries per segment

--- a/components/expander.py
+++ b/components/expander.py
@@ -4,44 +4,7 @@ from typing import Dict, Optional
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-
-
-# ---------------------------------------------------------------------------
-# Rotary Positional Embeddings with global cache
-# ---------------------------------------------------------------------------
-class RotaryCache:
-    """Lazy global cache keyed by (max_seq_len, dim, device, dtype)."""
-
-    _store: Dict[tuple[int, int, int, int], tuple[torch.Tensor, torch.Tensor]] = {}
-
-    @staticmethod
-    def get(max_seq: int, dim: int, device: torch.device, dtype: torch.dtype) -> tuple[torch.Tensor, torch.Tensor]:
-        key = (max_seq, dim, device.index if device.type == "cuda" else -1, torch.dtype(dtype).value)
-        if key not in RotaryCache._store:
-            inv_freq = 1.0 / (10000 ** (torch.arange(0, dim, 2, device=device, dtype=torch.float32) / dim))
-            t = torch.arange(max_seq, device=device, dtype=torch.float32)
-            freqs = torch.outer(t, inv_freq)
-            cos = freqs.cos()[None, None, :, :].to(dtype)
-            sin = freqs.sin()[None, None, :, :].to(dtype)
-            RotaryCache._store[key] = (cos, sin)
-        return RotaryCache._store[key]
-
-
-def apply_rope(x: torch.Tensor, seq_pos: slice | None = None) -> torch.Tensor:
-    """Apply Rotary Positional Embedding to a (B,H,S,D) tensor."""
-
-    cos, sin = RotaryCache.get(x.size(-2), x.size(-1), x.device, x.dtype)
-    if seq_pos is not None:
-        cos, sin = cos[..., seq_pos, :], sin[..., seq_pos, :]
-
-    x_even, x_odd = x[..., ::2], x[..., 1::2]
-    out = torch.empty_like(x)
-    out[..., ::2] = x_even * cos - x_odd * sin
-    out[..., 1::2] = x_even * sin + x_odd * cos
-    return out
-
-
-# ---------------------------------------------------------------------------
+from .rope import RotaryCache, apply_rope
 # SwiGLU Feed Forward
 # ---------------------------------------------------------------------------
 class SwiGLU(nn.Module):

--- a/components/hierarchical_autoencoder.py
+++ b/components/hierarchical_autoencoder.py
@@ -80,7 +80,6 @@ class HierarchicalAutoencoder(nn.Module):
                 dim=config['dim'], heads=config['heads'], window=config['window'],
                 num_encoder_layers=config.get('num_encoder_layers', 3),
                 encoder_ffn_dim_multiplier=config.get('encoder_ffn_dim_multiplier', 4),
-                max_seq_len_encoder=config.get('max_seq_len_encoder', 4096),
                 num_queries=config['num_queries'],
                 codebook_size=config['codebook_size'], beta=config['beta']
             )
@@ -118,7 +117,6 @@ class HierarchicalAutoencoder(nn.Module):
                 num_layers=self.top_transformer_config.get('num_layers', 4),
                 num_heads=self.top_transformer_config.get('num_heads', 8),
                 ffn_dim_multiplier=self.top_transformer_config.get('ffn_dim_multiplier', 4),
-                max_seq_len=self.top_transformer_config.get('max_seq_len', 2048),
                 output_lm_logits=self.top_transformer_config.get('output_lm_logits', True)
             )
             print(

--- a/components/rope.py
+++ b/components/rope.py
@@ -1,0 +1,32 @@
+import torch
+from typing import Dict
+
+class RotaryCache:
+    """Lazy global cache keyed by (max_seq_len, dim, device, dtype)."""
+
+    _store: Dict[tuple[int, int, int, int], tuple[torch.Tensor, torch.Tensor]] = {}
+
+    @staticmethod
+    def get(max_seq: int, dim: int, device: torch.device, dtype: torch.dtype) -> tuple[torch.Tensor, torch.Tensor]:
+        key = (max_seq, dim, device.index if device.type == "cuda" else -1, torch.dtype(dtype).value)
+        if key not in RotaryCache._store:
+            inv_freq = 1.0 / (10000 ** (torch.arange(0, dim, 2, device=device, dtype=torch.float32) / dim))
+            t = torch.arange(max_seq, device=device, dtype=torch.float32)
+            freqs = torch.outer(t, inv_freq)
+            cos = freqs.cos()[None, None, :, :].to(dtype)
+            sin = freqs.sin()[None, None, :, :].to(dtype)
+            RotaryCache._store[key] = (cos, sin)
+        return RotaryCache._store[key]
+
+
+def apply_rope(x: torch.Tensor, seq_pos: slice | None = None) -> torch.Tensor:
+    """Apply Rotary Positional Embedding to a (B,H,S,D) tensor."""
+    cos, sin = RotaryCache.get(x.size(-2), x.size(-1), x.device, x.dtype)
+    if seq_pos is not None:
+        cos, sin = cos[..., seq_pos, :], sin[..., seq_pos, :]
+
+    x_even, x_odd = x[..., ::2], x[..., 1::2]
+    out = torch.empty_like(x)
+    out[..., ::2] = x_even * cos - x_odd * sin
+    out[..., 1::2] = x_even * sin + x_odd * cos
+    return out


### PR DESCRIPTION
## Summary
- implement reusable RoPE helper
- switch Expander to import RoPE helper
- apply RoPE in sliding window attention modules
- rewrite CodeSequenceTransformer to use RoPE-based blocks
- remove unused positional encodings from sliding window encoder
- adjust compressor and autoencoder initialization

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685771950fe48326acc98899934f6cf6