### PR TITLE
Use SwiGLU for feed-forward layers

### DIFF
--- a/components/__init__.py
+++ b/components/__init__.py
@@ -2,3 +2,4 @@ from .vector_quantizer import VectorQuantizer
 from .learned_query_attention import LearnedQueryAttention
 from .utils import token_entropy, entropy_segments, build_segment_queries_mask
 from .hierarchical_autoencoder import HierarchicalAutoencoder
+from .swiglu import SwiGLU

--- a/components/expander.py
+++ b/components/expander.py
@@ -5,18 +5,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from .rope import RotaryCache, apply_rope
-# SwiGLU Feed Forward
-# ---------------------------------------------------------------------------
-class SwiGLU(nn.Module):
-    def __init__(self, d_model: int, hidden_dim: int):
-        super().__init__()
-        self.w1 = nn.Linear(d_model, hidden_dim * 2)
-        self.w2 = nn.Linear(hidden_dim, d_model)
-
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        a, b = self.w1(x).chunk(2, dim=-1)
-        x = F.silu(a) * b
-        return self.w2(x)
+from .swiglu import SwiGLU
 
 
 # ---------------------------------------------------------------------------

--- a/components/sliding_window_attention.py
+++ b/components/sliding_window_attention.py
@@ -6,6 +6,7 @@ from torch.nn.attention.flex_attention import (
     create_block_mask         # helper to build sparse mask
 )
 from .rope import apply_rope
+from .swiglu import SwiGLU
 from typing import Optional, Tuple
 
 @torch.compile
@@ -292,11 +293,7 @@ class SlidingWindowTransformerBlock(nn.Module):
         # Second sub-block: Feed-Forward Network
         self.norm2 = nn.RMSNorm(dim)
         ffn_hidden_dim = dim * ffn_dim_multiplier
-        self.ffn = nn.Sequential(
-            nn.Linear(dim, ffn_hidden_dim),
-            nn.GELU(),
-            nn.Linear(ffn_hidden_dim, dim)
-        )
+        self.ffn = SwiGLU(dim, ffn_hidden_dim)
 
     def forward(self, x: torch.Tensor,
                 key_padding_mask: Optional[torch.Tensor] = None) -> torch.Tensor:

--- a/components/swiglu.py
+++ b/components/swiglu.py
@@ -1,0 +1,15 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+class SwiGLU(nn.Module):
+    """Feed-forward block with SwiGLU activation."""
+    def __init__(self, d_model: int, hidden_dim: int):
+        super().__init__()
+        self.w1 = nn.Linear(d_model, hidden_dim * 2)
+        self.w2 = nn.Linear(hidden_dim, d_model)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        a, b = self.w1(x).chunk(2, dim=-1)
+        x = F.silu(a) * b
+        return self.w2(x)


### PR DESCRIPTION
## Summary
- centralize `SwiGLU` in its own module
- import and use `SwiGLU` in the expander and sliding window attention blocks
- update `__init__.py`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68577b96b6a0832694d73d748259f0cf