### PR TITLE
Add streaming top code generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,18 @@ Key modules under `components/` include:
 - **HierarchicalAELM** – Adapter that exposes trained autoencoder checkpoints as
   language models for evaluation with the LM harness.
 
+
 See `notes.md` for additional design thoughts.
+
+## Generation
+
+The `generate_bytes` method performs end‑to‑end text generation. A prompt is
+first compressed to top‑level codes. These codes seed the
+`CodeSequenceTransformer`, which autoregressively predicts one new code at a
+time. After each prediction the expander stack decodes the updated code
+sequence back into bytes so the output can grow beyond the original compressed
+length. Generation stops when an EOS code is produced or when a maximum length
+is reached.
 
 ## Evaluation
 

--- a/tests/test_generation.py
+++ b/tests/test_generation.py
@@ -1,0 +1,56 @@
+import torch
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from components.hierarchical_autoencoder import HierarchicalAutoencoder
+
+
+def build_model():
+    comp_cfg = [{
+        "dim": 4,
+        "heads": 1,
+        "window": 2,
+        "num_encoder_layers": 1,
+        "encoder_ffn_dim_multiplier": 2,
+        "num_queries": 1,
+        "codebook_size": 4,
+        "beta": 0.25,
+    }]
+    model = HierarchicalAutoencoder(
+        num_levels=1,
+        compressor_level_configs=comp_cfg,
+        initial_vocab_size=259,
+        expander_dim_scale=1.0,
+        expander_num_enc_layers=1,
+        expander_num_dec_layers=1,
+        expander_heads_scale=1.0,
+        expander_eos_id=1,
+        expander_max_len=8,
+        propagate_key_padding_mask=True,
+        aux_lm_loss_weight=0.0,
+        top_transformer_config={
+            "dim": 4,
+            "num_layers": 1,
+            "num_heads": 1,
+            "ffn_dim_multiplier": 2,
+            "output_lm_logits": True,
+        },
+        top_lm_loss_weight=0.0,
+    )
+    model.eval()
+    return model
+
+
+def test_generate_bytes_longer_than_compressed():
+    torch.manual_seed(0)
+    model = build_model()
+    tokens = torch.tensor([[2, 3, 4, 5]], dtype=torch.long)
+    kpm = torch.zeros_like(tokens, dtype=torch.bool)
+
+    comp_res = model.compress(tokens, key_padding_mask=kpm)
+    compressed_len = comp_res["top_codes"].size(1)
+
+    out = model.generate_bytes(tokens, key_padding_mask=kpm, max_len_override=5)
+    assert out.size(1) > compressed_len


### PR DESCRIPTION
## Summary
- add code generation helper to `CodeSequenceTransformer`
- allow `HierarchicalAutoencoder.generate_bytes` to iteratively generate top codes and decode bytes
- add regression test exercising generation loop
- document the new generation behaviour in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ddf09881c8326b6e8d083ca0004b1