### PR TITLE
Handle special tokens in VectorQuantizer

### DIFF
--- a/tests/test_vector_quantizer.py
+++ b/tests/test_vector_quantizer.py
@@ -7,14 +7,16 @@ from components.vector_quantizer import VectorQuantizer
 
 def test_vector_quantizer_forward_no_ema():
     torch.manual_seed(0)
-    vq = VectorQuantizer(K=8, D=4, ema=False)
+    vq = VectorQuantizer(K=8, D=4, ema=False, bos_token_id=0, eos_token_id=1)
     x = torch.randn(2, 3, 4)
     z_q, vq_loss, indices, perplexity = vq(x)
     assert z_q.shape == x.shape
     assert vq_loss.requires_grad
     assert indices.shape == (2, 3)
     assert perplexity.dim() == 0
-    counts = torch.bincount(indices.view(-1), minlength=vq.K).float().clamp(min=vq.eps)
+    counts = torch.bincount(indices.view(-1), minlength=vq.K).float()
+    counts[torch.tensor([vq.bos_token_id, vq.eos_token_id])] = 0
+    counts = counts.clamp(min=vq.eps)
     probs = counts / (counts.sum() + vq.eps)
     entropy = -(probs.double() * probs.double().log()).sum()
     expected = entropy.exp().float()


### PR DESCRIPTION
## Summary
- allow passing BOS/EOS token ids to `VectorQuantizer`
- exclude reserved codes from EMA updates, resets and perplexity
- adjust dead code resets and perplexity calculations
- update tests for the new layer options

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685edce292d8832699633a0efd5616a7