### PR TITLE
Implement EOP-aware vector quantizer and segment boundaries

### DIFF
--- a/tests/test_vector_quantizer.py
+++ b/tests/test_vector_quantizer.py
@@ -7,14 +7,16 @@ from components.vector_quantizer import VectorQuantizer
 
 def test_vector_quantizer_forward_no_ema():
     torch.manual_seed(0)
-    vq = VectorQuantizer(K=8, D=4, ema=False)
+    vq = VectorQuantizer(K=8, D=4, ema=False, eop_token_id=0)
     x = torch.randn(2, 3, 4)
     z_q, vq_loss, indices, perplexity = vq(x)
     assert z_q.shape == x.shape
     assert vq_loss.requires_grad
     assert indices.shape == (2, 3)
     assert perplexity.dim() == 0
-    counts = torch.bincount(indices.view(-1), minlength=vq.K).float().clamp(min=vq.eps)
+    counts = torch.bincount(indices.view(-1), minlength=vq.K).float()
+    counts[vq.eop_token_id] = 0
+    counts = counts.clamp(min=vq.eps)
     probs = counts / (counts.sum() + vq.eps)
     entropy = -(probs.double() * probs.double().log()).sum()
     expected = entropy.exp().float()


### PR DESCRIPTION
## Summary
- add `eop_token_id` support to `VectorQuantizer`
- exclude EOP token from EMA updates, resets and perplexity
- return segmentation end mask from `ByteSegmentCompressor`
- propagate segmentation info through `HierarchicalAutoencoder`
- update tests for new `VectorQuantizer` API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ef3dbfc7c8326919bb76a3af17569