### PR TITLE
Optimize code generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,11 +72,10 @@ See `notes.md` for additional design thoughts.
 
 The `generate_bytes` method performs end‑to‑end text generation. A prompt is
 first compressed to top‑level codes. These codes seed the
-`CodeSequenceTransformer`, which autoregressively predicts one new code at a
-time. After each prediction the expander stack decodes the updated code
-sequence back into bytes so the output can grow beyond the original compressed
-length. Generation stops when an EOS code is produced or when a maximum length
-is reached.
+`CodeSequenceTransformer`, which autoregressively predicts additional codes
+until an EOS token is produced or a maximum length is reached. Once the full
+code sequence is ready, the expander stack decodes it in a single pass back
+into bytes.
 
 ## Evaluation
 

--- a/components/hierarchical_autoencoder.py
+++ b/components/hierarchical_autoencoder.py
@@ -645,48 +645,32 @@ class HierarchicalAutoencoder(nn.Module):
         top_codes = compression_results['top_codes']
         kpm_for_top_expander_input = compression_results['final_key_padding_mask']
 
-        # Decode the prefix produced by the compressors
+        generated_top_codes = top_codes
+        generated_kpm = kpm_for_top_expander_input
+
+        if self.code_sequence_transformer is not None:
+            # Autoregressively extend the sequence of top codes
+            while True:
+                if max_len_override is not None and generated_top_codes.size(1) >= max_len_override:
+                    break
+
+                next_code = self.code_sequence_transformer.generate_codes(
+                    prefix=generated_top_codes,
+                    key_padding_mask=generated_kpm,
+                )
+                generated_top_codes = torch.cat([generated_top_codes, next_code], dim=1)
+                if generated_kpm is not None:
+                    pad = torch.zeros(generated_kpm.size(0), 1, dtype=generated_kpm.dtype, device=generated_kpm.device)
+                    generated_kpm = torch.cat([generated_kpm, pad], dim=1)
+
+                if (next_code == self.expander_eos_id).all():
+                    break
+
         decomp = self.decompress(
-            top_codes=top_codes,
-            top_codes_key_padding_mask=kpm_for_top_expander_input,
+            top_codes=generated_top_codes,
+            top_codes_key_padding_mask=generated_kpm,
             targets_for_teacher_forcing=None,
             max_len_override=max_len_override,
         )
-        reconstructed = decomp['final_reconstructed_tokens']
 
-        if self.code_sequence_transformer is None:
-            return reconstructed
-
-        generated_top_codes = top_codes
-        generated_kpm = kpm_for_top_expander_input
-        prev_len = reconstructed.size(1)
-
-        # Continue generating top codes one by one
-        while True:
-            if max_len_override is not None and generated_top_codes.size(1) >= max_len_override:
-                break
-
-            next_code = self.code_sequence_transformer.generate_codes(
-                prefix=generated_top_codes,
-                key_padding_mask=generated_kpm,
-            )
-            generated_top_codes = torch.cat([generated_top_codes, next_code], dim=1)
-            if generated_kpm is not None:
-                pad = torch.zeros(generated_kpm.size(0), 1, dtype=generated_kpm.dtype, device=generated_kpm.device)
-                generated_kpm = torch.cat([generated_kpm, pad], dim=1)
-
-            decomp = self.decompress(
-                top_codes=generated_top_codes,
-                top_codes_key_padding_mask=generated_kpm,
-                targets_for_teacher_forcing=None,
-                max_len_override=max_len_override,
-            )
-            new_tokens = decomp['final_reconstructed_tokens']
-            reconstructed = torch.cat([reconstructed, new_tokens[:, prev_len:]], dim=1)
-            prev_len = new_tokens.size(1)
-
-            # Stop if EOS code generated
-            if (next_code == self.expander_eos_id).all():
-                break
-
-        return reconstructed
+        return decomp['final_reconstructed_tokens']


### PR DESCRIPTION
## Summary
- streamline generation by batching top code prediction before decompression
- document updated flow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686357bfa08083269dedda3951919b13