### PR TITLE
Add config file CLI option

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 An experimental hierarchical autoencoder for compressing and reconstructing raw
 text at the byte level. The project explores whether long sequences can be
 represented with a compact set of discrete codes while still allowing faithful
-recovery. Training and dataset parameters are configured in `config.py`.
+recovery. Training and dataset parameters are configured in a Python config file
+(`config.py` by default).
 
 ## Overview
 
@@ -31,7 +32,13 @@ Run the training loop:
 python train.py
 ```
 
-All experiment settings live in the `exp_config` dictionary within `config.py`.  Edit values there to change model size, dataset selection and training options. Training normally runs for `exp_config['num_epochs']`, but you can specify `exp_config['max_steps']` to cap the total number of optimizer steps instead.
+Specify a different config file with `--config`:
+
+```bash
+python train.py --config tiny_config.py
+```
+
+All experiment settings live in the `exp_config` dictionary within your chosen config file. Edit values there to change model size, dataset selection and training options. Training normally runs for `exp_config['num_epochs']`, but you can specify `exp_config['max_steps']` to cap the total number of optimizer steps instead.
 
 Checkpoints are saved to `exp_config['checkpoint_dir']` every `exp_config['checkpoint_interval']` steps.  To resume training, set `exp_config['resume_from_checkpoint']` to the path of a saved checkpoint.
 

--- a/train.py
+++ b/train.py
@@ -3,6 +3,8 @@ import math
 import sys
 import time
 from collections import defaultdict
+import argparse
+import importlib.util
 
 import torch
 from datasets import load_dataset, Dataset  # Import Dataset for the dummy data
@@ -16,7 +18,26 @@ import mlflow  # Logging with MLflow
 # Assuming HierarchicalAutoencoder is in abstractinator.py and has KPM updates
 from components import HierarchicalAutoencoder
 from components.utils import short_num
-from config import DEVICE, N_CPU, exp_config
+
+parser = argparse.ArgumentParser(description="Training script for HierarchicalAutoencoder")
+parser.add_argument(
+    "--config",
+    type=str,
+    default="config.py",
+    help="Path to the configuration Python file",
+)
+args = parser.parse_args()
+
+def load_config(path: str):
+    spec = importlib.util.spec_from_file_location("config_module", path)
+    config_module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(config_module)
+    return config_module
+
+config = load_config(args.config)
+DEVICE = config.DEVICE
+N_CPU = config.N_CPU
+exp_config = config.exp_config
 
 torch.set_float32_matmul_precision("high")
 torch.set_default_dtype(torch.bfloat16)
@@ -27,7 +48,7 @@ torch._dynamo.config.recompile_limit = 128
 print(f"Using device: {DEVICE}")
 
 # --- Experiment Configuration ---
-# Loaded from config.py
+# Loaded from the provided config file
 
 # --- MLflow Setup ---
 # See https://mlflow.org/docs/latest/python_api/mlflow.html for API details


### PR DESCRIPTION
## Summary
- allow selecting a config file when running `train.py`
- document the new `--config` flag in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68641ea8b0f88326883de3885d38510f