### PR TITLE
Add MLflow UI usage to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,13 @@ All experiment settings live in the `exp_config` dictionary within your chosen c
 Checkpoints are saved to `exp_config['checkpoint_dir']` every `exp_config['checkpoint_interval']` steps.  To resume training, set `exp_config['resume_from_checkpoint']` to the path of a saved checkpoint.
 
 Training metrics and sample outputs are logged with [MLflow](https://mlflow.org/docs/latest/python_api/mlflow.html). If `exp_config['project_name']` is set, logs are stored under `./mlruns/<project_name>`.
+You can monitor a run locally by launching the MLflow UI:
+
+```bash
+mlflow ui --backend-store-uri ./mlruns/<project_name>
+```
+
+Then open the shown URL in your browser to view metrics and artifacts as training progresses.
 
 ## Loss Components
 


### PR DESCRIPTION
## Summary
- document how to launch `mlflow ui` to monitor training logs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686439dcde5c83269431cb5c1f3e8b82