### PR TITLE
Make CodeSequenceTransformer causal

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ Key modules under `components/` include:
 - **CodeExpander** – A sequence‑to‑sequence transformer that learns to map a
   sequence of higher-level codes back into the lower-level sequence from which
   they were produced. During generation it autoregressively expands codes.
-- **CodeSequenceTransformer** – Optional encoder stack for modeling the top-level
-  codes themselves.  It can predict the next code and provide contextual
+- **CodeSequenceTransformer** – Optional causal encoder stack for modeling the
+  top-level codes themselves.  It predicts the next code and provides contextual
   embeddings for the decoder.
 - **HierarchicalAutoencoder** – Orchestrates multiple compressors and expanders.
   Each level compresses further than the last, and decompression reverses the

--- a/components/code_sequence_transformer.py
+++ b/components/code_sequence_transformer.py
@@ -6,8 +6,9 @@ from .expander import EncoderBlock
 # Disable torch.compile on this module to keep unit tests lightweight
 class CodeSequenceTransformer(nn.Module):
     """
-    A standard Transformer encoder stack to process sequences of codes.
-    Can be used for language modeling on codes or extracting contextual representations.
+    A causal Transformer encoder stack to process sequences of codes.
+    It can be used for language modeling on codes or extracting contextual
+    representations.
     """
 
     def __init__(self,
@@ -25,7 +26,7 @@ class CodeSequenceTransformer(nn.Module):
 
         self.token_embedding = nn.Embedding(code_vocab_size, dim)
         self.encoder = nn.ModuleList([
-            EncoderBlock(dim, num_heads, dim * ffn_dim_multiplier)
+            EncoderBlock(dim, num_heads, dim * ffn_dim_multiplier, causal=True)
             for _ in range(num_layers)
         ])
         self.final_norm = nn.RMSNorm(dim)

--- a/components/expander.py
+++ b/components/expander.py
@@ -74,10 +74,10 @@ class MultiHeadAttentionRoPE(nn.Module):
 # Transformer Blocks
 # ---------------------------------------------------------------------------
 class EncoderBlock(nn.Module):
-    def __init__(self, d_model: int, num_heads: int, ffn_dim: int):
+    def __init__(self, d_model: int, num_heads: int, ffn_dim: int, causal: bool = False):
         super().__init__()
         self.norm1 = nn.RMSNorm(d_model)
-        self.attn = MultiHeadAttentionRoPE(d_model, num_heads)
+        self.attn = MultiHeadAttentionRoPE(d_model, num_heads, causal=causal)
         self.norm2 = nn.RMSNorm(d_model)
         self.ffn = SwiGLU(d_model, ffn_dim)
 


### PR DESCRIPTION
## Summary
- implement causal flag for `EncoderBlock`
- use causal encoder blocks inside `CodeSequenceTransformer`
- clarify that `CodeSequenceTransformer` is causal in docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686480119eb08326866500b7e6b3da59