### PR TITLE
Add decoder-only expander flag

### DIFF
--- a/config.py
+++ b/config.py
@@ -32,6 +32,7 @@ exp_config = {
     "expander_heads_scale": 1.0,
     "expander_eos_id": 1,
     "expander_max_len": 2048,
+    "use_decoder_only_expander": False,
     "propagate_key_padding_mask": True,
     "aux_lm_loss_weight": 1.0,
     "top_lm_loss_weight": 0.2,

--- a/super_tiny_config.py
+++ b/super_tiny_config.py
@@ -32,6 +32,7 @@ exp_config = {
     "expander_heads_scale": 1.0,
     "expander_eos_id": 1,
     "expander_max_len": 2048,
+    "use_decoder_only_expander": False,
     "propagate_key_padding_mask": True,
     "aux_lm_loss_weight": 1.0,
     "top_lm_loss_weight": 1.0,

--- a/tiny_config.py
+++ b/tiny_config.py
@@ -32,6 +32,7 @@ exp_config = {
     "expander_heads_scale": 1.0,
     "expander_eos_id": 1,
     "expander_max_len": 2048,
+    "use_decoder_only_expander": False,
     "propagate_key_padding_mask": True,
     "aux_lm_loss_weight": 1.0,
     "top_lm_loss_weight": 0.2,


### PR DESCRIPTION
## Summary
- add `use_decoder_only_expander` option to `exp_config` in all config files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865637d14a083268b6363a56b5409cf