### PR TITLE
Add SlidingWindowCrossAttention module

### DIFF
--- a/tests/test_sliding_window_cross_attention.py
+++ b/tests/test_sliding_window_cross_attention.py
@@ -1,0 +1,28 @@
+import torch
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from components.sliding_window_attention import SlidingWindowCrossAttention
+
+
+def test_cross_window_mask():
+    attn = SlidingWindowCrossAttention(embed_dim=4, num_heads=1, window_size=1)
+    mask = attn._cross_window_mask(4, 5, torch.device("cpu"))
+    expected = torch.tensor(
+        [[False, False, True, True, True],
+         [False, False, False, True, True],
+         [True, False, False, False, True],
+         [True, True, False, False, False]],
+        dtype=torch.bool,
+    )
+    assert torch.equal(mask, expected)
+
+
+def test_forward_output_shape():
+    attn = SlidingWindowCrossAttention(embed_dim=8, num_heads=2, window_size=1)
+    q = torch.randn(2, 3, 8)
+    kv = torch.randn(2, 5, 8)
+    out = attn(q, kv, kv)
+    assert out.shape == (2, 3, 8)


### PR DESCRIPTION
## Summary
- implement `SlidingWindowCrossAttention` for decoder cross attention with fixed window
- add tests checking window masking and forward output shape

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865654940f88326ba36e5c7c1e8bfdb