### PR TITLE
Add sliding window cross attention

### DIFF
--- a/components/sliding_window_attention.py
+++ b/components/sliding_window_attention.py
@@ -263,6 +263,76 @@ class SlidingWindowAttention(nn.Module):
 
         return output
 
+
+class SlidingWindowCrossAttention(nn.Module):
+    """Sliding-window cross attention with separate query and key/value sequences."""
+
+    def __init__(self, embed_dim: int, num_heads: int, window_size: int,
+                 bias: bool = True) -> None:
+        super().__init__()
+        if embed_dim % num_heads != 0:
+            raise ValueError(
+                f"embed_dim ({embed_dim}) must be divisible by num_heads ({num_heads})."
+            )
+        self.embed_dim = embed_dim
+        self.num_heads = num_heads
+        self.head_dim = embed_dim // num_heads
+        self.window_size = window_size
+
+        self.q_proj = nn.Linear(embed_dim, embed_dim, bias=bias)
+        self.k_proj = nn.Linear(embed_dim, embed_dim, bias=bias)
+        self.v_proj = nn.Linear(embed_dim, embed_dim, bias=bias)
+        self.out_proj = nn.Linear(embed_dim, embed_dim, bias=bias)
+
+    def _cross_window_mask(self, q_len: int, kv_len: int,
+                           device: torch.device) -> torch.Tensor:
+        """Mask restricting queries to attend within a retrospective window."""
+        q_idx = torch.arange(q_len, device=device)[:, None]
+        kv_idx = torch.arange(kv_len, device=device)[None, :]
+        rel_pos = kv_idx - q_idx
+        mask = (rel_pos > 0) | (rel_pos < -self.window_size)
+        return mask
+
+    def forward(self,
+                query: torch.Tensor,
+                key: torch.Tensor,
+                value: torch.Tensor,
+                attn_mask: Optional[torch.Tensor] = None,
+                key_padding_mask: Optional[torch.Tensor] = None) -> torch.Tensor:
+        B, S_q, D = query.shape
+        if D != self.embed_dim or key.size(2) != self.embed_dim or value.size(2) != self.embed_dim:
+            raise ValueError("embed_dim mismatch")
+        S_k = key.size(1)
+
+        q = self.q_proj(query).view(B, S_q, self.num_heads, self.head_dim).transpose(1, 2)
+        k = self.k_proj(key).view(B, S_k, self.num_heads, self.head_dim).transpose(1, 2)
+        v = self.v_proj(value).view(B, S_k, self.num_heads, self.head_dim).transpose(1, 2)
+
+        q = apply_rope(q)
+        k = apply_rope(k)
+        q = q * (self.head_dim ** -0.5)
+
+        attn_scores = torch.matmul(q, k.transpose(-2, -1))
+
+        combined_mask = self._cross_window_mask(S_q, S_k, query.device)
+
+        if attn_mask is not None:
+            combined_mask = combined_mask | attn_mask.to(device=query.device, dtype=torch.bool)
+
+        combined_mask = combined_mask.unsqueeze(0).unsqueeze(0)
+
+        if key_padding_mask is not None:
+            expanded_kpm = key_padding_mask.unsqueeze(1).unsqueeze(2)
+            combined_mask = combined_mask | expanded_kpm
+
+        attn_scores = attn_scores.masked_fill(combined_mask, float('-inf'))
+        attn_probs = F.softmax(attn_scores, dim=-1)
+        output = torch.matmul(attn_probs, v)
+        output = output.transpose(1, 2).contiguous().view(B, S_q, self.embed_dim)
+        output = self.out_proj(output)
+
+        return output
+
 # @torch.compile
 class SlidingWindowTransformerBlock(nn.Module):
     """

--- a/tests/test_sliding_window_cross_attention.py
+++ b/tests/test_sliding_window_cross_attention.py
@@ -1,0 +1,28 @@
+import os
+import sys
+import torch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from components.sliding_window_attention import SlidingWindowCrossAttention
+
+
+def test_cross_window_mask():
+    attn = SlidingWindowCrossAttention(embed_dim=4, num_heads=1, window_size=2)
+    mask = attn._cross_window_mask(3, 5, device=torch.device("cpu"))
+    expected = torch.tensor([
+        [False, True, True, True, True],
+        [False, False, True, True, True],
+        [False, False, False, True, True],
+    ])
+    assert torch.equal(mask, expected)
+
+
+def test_cross_attention_forward_shape():
+    torch.manual_seed(0)
+    attn = SlidingWindowCrossAttention(embed_dim=4, num_heads=2, window_size=1)
+    q = torch.randn(2, 3, 4)
+    k = torch.randn(2, 4, 4)
+    v = torch.randn(2, 4, 4)
+    out = attn(q, k, v)
+    assert out.shape == (2, 3, 4)


### PR DESCRIPTION
## Summary
- implement `SlidingWindowCrossAttention` for decoder-side local cross attention
- test mask creation and forward shape

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865654940f88326ba36e5c7c1e8bfdb