### PR TITLE
Expose pre-VQ embeddings

### DIFF
--- a/components/byte_segment_compressor.py
+++ b/components/byte_segment_compressor.py
@@ -188,6 +188,7 @@ class ByteSegmentCompressor(nn.Module):
             'patch_end_mask': patch_end_mask,
             'encoder_logits': logits,
             'current_codebook_perplexity': codebook_perplexity,
-            'smoothed_codebook_perplexity': perplexity
+            'smoothed_codebook_perplexity': perplexity,
+            'pre_vq_embeddings': pooled_embeddings,
         }
         return return_dict

--- a/tests/test_continuous_transformer.py
+++ b/tests/test_continuous_transformer.py
@@ -14,6 +14,7 @@ def test_continuous_transformer_forward():
     model = CodeSequenceTransformer(embed_dim=4, dim=8, num_layers=1, num_heads=1, vq=vq)
     x = torch.randn(2, 3, 4)
     out = model(x)
+    assert out["predictions_pre_vq"].shape == x.shape
     assert out["predictions"].shape == x.shape
     assert out["indices"].shape == (2, 3)
     assert out["vq_loss"].requires_grad


### PR DESCRIPTION
## Summary
- keep pooled embeddings before VQ in `ByteSegmentCompressor`
- track pre‑quantized embeddings in `HierarchicalAutoencoder.compress`
- expose pre‑VQ predictions from `CodeSequenceTransformer`
- compute LM loss on pre‑VQ embeddings in `HierarchicalAutoencoder`
- use pre‑VQ vectors when generating bytes
- check for new output in unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68688b6a859c8326a28d54879c63fdbf