### PR TITLE
Add config option for evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,5 +155,5 @@ To test a model you've trained with `train.py`, point the harness at the saved
 checkpoint using the `hier_ae` model type:
 
 ```bash
-python evaluate.py --model hier_ae --model_args checkpoint=./checkpoints/checkpoint_step1000.pt
+python evaluate.py --model hier_ae --model_args checkpoint=./checkpoints/checkpoint_step1000.pt --config config.py
 ```

--- a/evaluate.py
+++ b/evaluate.py
@@ -1,7 +1,8 @@
 import argparse
 import json
+import importlib.util
 
-from lm_eval import evaluator
+from lm_eval import evaluator, utils
 import components.hae_lm  # registers HierarchicalAELM with lm_eval
 
 DEFAULT_TASKS = [
@@ -24,6 +25,12 @@ def main():
         help="Model arguments string passed to the evaluation harness",
     )
     parser.add_argument(
+        "--config",
+        type=str,
+        default="config.py",
+        help="Path to configuration file for hier_ae models",
+    )
+    parser.add_argument(
         "--tasks",
         nargs="+",
         default=DEFAULT_TASKS,
@@ -40,13 +47,37 @@ def main():
     )
     args = parser.parse_args()
 
+    if args.model == "hier_ae":
+        # Load configuration for HierarchicalAELM
+        spec = importlib.util.spec_from_file_location("config_module", args.config)
+        config_module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(config_module)
+        exp_config = config_module.exp_config
+        device = args.device or getattr(config_module, "DEVICE", None)
+
+        model_args = utils.simple_parse_args_string(args.model_args or "")
+        checkpoint = model_args.get("checkpoint")
+        if checkpoint is None:
+            raise ValueError("model_args must include 'checkpoint' for hier_ae model")
+
+        lm = components.hae_lm.HierarchicalAELM(
+            checkpoint=checkpoint,
+            config=exp_config,
+            device=device,
+        )
+        model_param = lm
+        model_args_param = None
+    else:
+        model_param = args.model
+        model_args_param = args.model_args
+
     results = evaluator.simple_evaluate(
-        model=args.model,
-        model_args=args.model_args,
+        model=model_param,
+        model_args=model_args_param,
         tasks=args.tasks,
         num_fewshot=args.num_fewshot,
         batch_size=args.batch_size,
-        device=args.device,
+        device=args.device if args.model != "hier_ae" else None,
         limit=args.limit,
     )
 


### PR DESCRIPTION
## Summary
- allow passing config file to evaluate.py
- let `HierarchicalAELM` load config dictionaries/paths
- update README usage example

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d3ae418248326bd58f3f5b5ea4d92