### PR TITLE
Add compressor compression targets

### DIFF
--- a/configs/base_config.py
+++ b/configs/base_config.py
@@ -26,6 +26,8 @@ class CompressorLevelConfig:
     beta: float = 1.0
     entropy_delta: float = 0.2
     entropy_abs_threshold: Optional[float] = None
+    target_compression_ratio: Optional[List[float]] = None
+    compression_loss_weight: float = 1.0
 
 
 @dataclass

--- a/configs/stage1_super_tiny_config.py
+++ b/configs/stage1_super_tiny_config.py
@@ -23,6 +23,8 @@ exp_config.compressor_level_configs = [
         beta=1.0,
         entropy_delta=0.2,
         entropy_abs_threshold=None,
+        target_compression_ratio=None,
+        compression_loss_weight=1.0,
     )
 ]
 exp_config.expander_num_enc_layers = 1

--- a/configs/stage2_super_tiny_config.py
+++ b/configs/stage2_super_tiny_config.py
@@ -24,6 +24,8 @@ exp_config.compressor_level_configs = [
         beta=1.0,
         entropy_delta=0.2,
         entropy_abs_threshold=None,
+        target_compression_ratio=None,
+        compression_loss_weight=1.0,
     )
 ]
 exp_config.expander_num_enc_layers = 1

--- a/configs/super_tiny_config.py
+++ b/configs/super_tiny_config.py
@@ -24,6 +24,8 @@ exp_config.compressor_level_configs = [
         beta=1.0,
         entropy_delta=0.2,
         entropy_abs_threshold=None,
+        target_compression_ratio=None,
+        compression_loss_weight=1.0,
     )
 ]
 exp_config.expander_num_enc_layers = 1

--- a/configs/tiny_config.py
+++ b/configs/tiny_config.py
@@ -24,6 +24,8 @@ exp_config.compressor_level_configs = [
         beta=1.0,
         entropy_delta=0.2,
         entropy_abs_threshold=None,
+        target_compression_ratio=None,
+        compression_loss_weight=1.0,
     )
 ]
 exp_config.top_transformer_config = TopTransformerConfig(

--- a/tests/test_compression_loss.py
+++ b/tests/test_compression_loss.py
@@ -1,0 +1,56 @@
+import os
+import sys
+import torch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from components.hierarchical_autoencoder import HierarchicalAutoencoder
+
+
+def build_model(target):
+    comp_cfg = [{
+        "dim": 4,
+        "heads": 1,
+        "window": 2,
+        "num_encoder_layers": 1,
+        "encoder_ffn_dim_multiplier": 2,
+        "num_queries": 1,
+        "codebook_size": 4,
+        "beta": 0.25,
+        "target_compression_ratio": target,
+        "compression_loss_weight": 1.0,
+    }]
+    return HierarchicalAutoencoder(
+        num_levels=1,
+        compressor_level_configs=comp_cfg,
+        initial_vocab_size=259,
+        expander_dim_scale=1.0,
+        expander_num_enc_layers=1,
+        expander_num_dec_layers=1,
+        expander_heads_scale=1.0,
+        expander_eos_id=1,
+        expander_max_len=8,
+        propagate_key_padding_mask=True,
+        aux_lm_loss_weight=0.0,
+        top_transformer_config=None,
+        top_lm_loss_weight=0.0,
+    )
+
+
+def test_forward_reports_compression_loss():
+    torch.manual_seed(0)
+    model = build_model(0.5)
+    tokens = torch.tensor([[2, 3, 4, 5]], dtype=torch.long)
+    out = model.forward(tokens)
+    assert "avg_compression_loss" in out
+    assert "compression_loss_L0" in out["compression_loss_details"]
+
+
+def test_different_targets_change_loss():
+    torch.manual_seed(0)
+    tokens = torch.tensor([[2, 3, 4, 5]], dtype=torch.long)
+    model_a = build_model(0.0)
+    model_b = build_model(1.0)
+    out_a = model_a.forward(tokens)
+    out_b = model_b.forward(tokens)
+    assert not torch.allclose(out_a["total_loss"], out_b["total_loss"])


### PR DESCRIPTION
## Summary
- add compression ratio target fields to config dataclass
- expose new compression loss values in configs
- track target ratios in HierarchicalAutoencoder and compute loss
- expose compression loss metrics in model forward
- basic tests for compression loss reporting and effect on total loss

## Testing
- `pytest -q` *(fails: torch._dynamo.exc.TorchRuntimeError: CUDA driver version is insufficient)*

------
https://chatgpt.com/codex/tasks/task_e_686ecadc96a48326ba8f1efc3fd51cef