### PR TITLE
Use FlexAttention only on CUDA

### DIFF
--- a/components/byte_segment_compressor.py
+++ b/components/byte_segment_compressor.py
@@ -50,14 +50,15 @@ class ByteSegmentCompressor(nn.Module):
         self.entropy_abs_threshold = entropy_abs_threshold
 
         # Initialize the token encoder
-        # Uses StackedSlidingWindowEncoder for token encoding
+        # Use FlexAttention only when CUDA is available
         self.encoder = StackedSlidingWindowEncoder(
             vocab_size=vocab_size,
             dim=dim,
             num_heads=heads,
             window_size=window,
             num_layers=num_encoder_layers,
-            ffn_dim_multiplier=encoder_ffn_dim_multiplier
+            ffn_dim_multiplier=encoder_ffn_dim_multiplier,
+            use_flex_attention=torch.cuda.is_available()
         )
 
         # Initialize the attention pooler that uses learned queries per segment

--- a/components/hierarchical_autoencoder.py
+++ b/components/hierarchical_autoencoder.py
@@ -260,7 +260,8 @@ class HierarchicalAutoencoder(nn.Module):
 
         compression_ratios: List[torch.Tensor] = []
         for in_len, out_len in zip(all_input_seq_lengths, all_output_seq_lengths):
-            ratio = torch.where(in_len > 0, out_len / in_len, out_len.new_tensor(0.0))
+            in_len_t = out_len.new_tensor(in_len)
+            ratio = torch.where(in_len_t > 0, out_len / in_len_t, out_len.new_tensor(0.0))
             compression_ratios.append(ratio)
             # compression_ratios.append(float((out_len / in_len).cpu()) if in_len.item() > 0 else 0.0)
         # compression_ratios = [(out_len / in_len) if in_len > 0 else 0.0 for in_len, out_len in


### PR DESCRIPTION
## Summary
- only use flex attention when CUDA is available by checking at initialization
- allow sliding window encoder/blocks to toggle flex attention
- fix compression ratio computation for PyTorch 2.x

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ef48d72288326b183afafce20ab4a