### PR TITLE
Expose VQ reset interval in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,9 @@ Key modules under `components/` include:
   vectors used by the compressors to pool variable-length segments into fixed
   representations.
 - **VectorQuantizer** – Discretizes segment embeddings with an EMA-updated
-  codebook and provides the VQ loss used during training.
+  codebook and provides the VQ loss used during training. The
+  frequency of dead-code resets is controlled by the
+  `vq_reset_interval` value in each compressor's config.
 - **SlidingWindowAttention** – Provides efficient local attention kernels for the
   token encoder used inside each compressor.
 - **HierarchicalAELM** – Adapter that exposes trained autoencoder checkpoints as

--- a/components/byte_segment_compressor.py
+++ b/components/byte_segment_compressor.py
@@ -48,6 +48,7 @@ class ByteSegmentCompressor(nn.Module):
         num_queries: int = 1,  # L: Number of queries per segment for the pooler
         codebook_size: int = 512,  # K: Number of codes in VQ codebook
         beta: float = 0.25,  # Beta for VQ commitment loss
+        vq_reset_interval: int = 250,
         entropy_delta: float = 0.2,
         entropy_abs_threshold: float | None = None,
     ):
@@ -111,7 +112,12 @@ class ByteSegmentCompressor(nn.Module):
             num_heads=heads,
         )
 
-        self.vq = VectorQuantizer(K=codebook_size, D=dim, beta=beta)
+        self.vq = VectorQuantizer(
+            K=codebook_size,
+            D=dim,
+            beta=beta,
+            reset_interval=vq_reset_interval,
+        )
 
     def forward(self, token_ids: torch.Tensor,
                 key_padding_mask: Optional[torch.Tensor] = None

--- a/components/hierarchical_autoencoder.py
+++ b/components/hierarchical_autoencoder.py
@@ -97,6 +97,7 @@ class HierarchicalAutoencoder(nn.Module):
                 num_queries=config['num_queries'],
                 codebook_size=config['codebook_size'],
                 beta=config['beta'],
+                vq_reset_interval=config.get('vq_reset_interval', 250),
                 entropy_delta=config.get('entropy_delta', 0.2),
                 entropy_abs_threshold=config.get('entropy_abs_threshold'),
             )

--- a/configs/base_config.py
+++ b/configs/base_config.py
@@ -27,6 +27,7 @@ class CompressorLevelConfig:
     num_queries: int = 1
     codebook_size: int = 49404
     beta: float = 1.0
+    vq_reset_interval: int = 250
     entropy_delta: float = 0.2
     entropy_abs_threshold: Optional[float] = None
     target_compression_ratio: Optional[List[float]] = None

--- a/tests/test_vq_reset_interval.py
+++ b/tests/test_vq_reset_interval.py
@@ -1,0 +1,38 @@
+import torch
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from components.hierarchical_autoencoder import HierarchicalAutoencoder
+
+
+def test_vq_reset_interval_configured():
+    comp_cfg = [{
+        "dim": 4,
+        "heads": 1,
+        "window": 2,
+        "num_encoder_layers": 1,
+        "encoder_ffn_dim_multiplier": 2,
+        "num_queries": 1,
+        "codebook_size": 4,
+        "beta": 0.25,
+        "vq_reset_interval": 99,
+    }]
+    model = HierarchicalAutoencoder(
+        num_levels=1,
+        compressor_level_configs=comp_cfg,
+        initial_vocab_size=259,
+        expander_dim_scale=1.0,
+        expander_num_enc_layers=1,
+        expander_num_dec_layers=1,
+        expander_heads_scale=1.0,
+        expander_eos_id=1,
+        expander_max_len=8,
+        propagate_key_padding_mask=True,
+        aux_lm_loss_weight=0.0,
+        top_transformer_config=None,
+        top_lm_loss_weight=0.0,
+    )
+
+    assert model.compressors[0].vq.reset_interval == 99


### PR DESCRIPTION
## Summary
- allow configuring how often vector quantizer codes reset via `vq_reset_interval`
- document the new option in README
- test that the interval propagates correctly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68701590e9c08326a4564f20f2531e93