### PR TITLE
Refactor tokenizer

### DIFF
--- a/components/__init__.py
+++ b/components/__init__.py
@@ -4,3 +4,4 @@ from .utils import token_entropy, entropy_segments, build_segment_queries_mask
 from .hierarchical_autoencoder import HierarchicalAutoencoder
 from .swiglu import SwiGLU
 from .expander import DecoderOnlyExpander
+from .tokenizer import ByteLevelTokenizer

--- a/components/hae_lm.py
+++ b/components/hae_lm.py
@@ -11,7 +11,7 @@ from lm_eval.api.model import LM
 from lm_eval.api.registry import register_model
 from lm_eval import utils
 
-from train import ByteLevelTokenizer
+from components.tokenizer import ByteLevelTokenizer
 from components import HierarchicalAutoencoder
 from configs.base_config import ExpConfig
 

--- a/components/tokenizer.py
+++ b/components/tokenizer.py
@@ -1,0 +1,76 @@
+"""Tokenizers used by Abstractinator."""
+
+from __future__ import annotations
+
+import torch
+
+
+class ByteLevelTokenizer:
+    """Simple byte-level tokenizer used for the demo training script.
+
+    The tokenizer works directly on raw UTF-8 bytes. Optionally BOS and EOS
+    tokens are inserted when encoding text. It keeps byte values (0-255) as
+    their own token IDs and reserves additional IDs for BOS, EOS and padding.
+
+    Attributes:
+        bos_id (int): Token ID prepended at the start of a sequence when
+            ``add_bos`` is ``True``.
+        eos_id (int): Token ID appended at the end of a sequence when
+            ``add_eos`` is ``True``.
+        pad_id (int): Token ID used for padding sequences.
+        add_bos (bool): Whether ``encode`` adds ``bos_id`` by default.
+        add_eos (bool): Whether ``encode`` adds ``eos_id`` by default.
+        vocab_size (int): Size of the tokenizer vocabulary.
+    """
+
+    def __init__(
+        self,
+        bos_id: int = 256,
+        eos_id: int = 257,
+        pad_id: int = 258,
+        add_bos: bool = True,
+        add_eos: bool = True,
+        expected_vocab_size: int | None = None,
+    ) -> None:
+        self.bos_id = bos_id
+        self.eos_id = eos_id
+        self.pad_id = pad_id
+        self.add_bos = add_bos
+        self.add_eos = add_eos
+        # Ensure initial_vocab_size in configuration matches this if provided.
+        # vocab_size here would be max(bos,eos,pad) + 1 = 259 for defaults.
+        self.vocab_size = max(bos_id, eos_id, pad_id) + 1
+        if expected_vocab_size is not None and self.vocab_size != expected_vocab_size:
+            print(
+                f"Warning: Tokenizer vocab_size ({self.vocab_size}) does not match "
+                f"expected value ({expected_vocab_size})."
+            )
+
+    def encode(
+        self, text: str, add_bos: bool | None = None, add_eos: bool | None = None
+    ) -> torch.Tensor:
+        if add_bos is None:
+            add_bos = self.add_bos
+        if add_eos is None:
+            add_eos = self.add_eos
+        raw_bytes = text.encode("utf-8", errors="ignore")
+        tokens: list[int] = []
+        if add_bos:
+            tokens.append(self.bos_id)
+        tokens.extend(raw_bytes)
+        if add_eos:
+            tokens.append(self.eos_id)
+        return torch.tensor(tokens, dtype=torch.int)
+
+    def decode(self, tokens: list[int] | torch.Tensor, cut_at_eos: bool = False) -> str:
+        if isinstance(tokens, torch.Tensor):
+            tokens = tokens.tolist()
+        if cut_at_eos and (self.eos_id in tokens):
+            try:
+                eos_index = tokens.index(self.eos_id)
+                tokens = tokens[:eos_index]
+            except ValueError:
+                pass
+        byte_list = [t for t in tokens if 0 <= t < 256]
+        return bytes(byte_list).decode("utf-8", errors="ignore")
+


### PR DESCRIPTION
## Summary
- move `ByteLevelTokenizer` into components package
- adjust imports to use new module
- expose tokenizer via `components.__init__`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871321ce3ac8326b2cd04c6851ad541