### PR TITLE
Fix compression totals in throughput metrics

### DIFF
--- a/tests/test_patch_throughput_ratio.py
+++ b/tests/test_patch_throughput_ratio.py
@@ -1,0 +1,59 @@
+import os
+import sys
+import torch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from components.hierarchical_autoencoder import HierarchicalAutoencoder
+
+
+def build_model():
+    comp_cfg = [{
+        "dim": 4,
+        "heads": 1,
+        "window": 2,
+        "num_encoder_layers": 1,
+        "encoder_ffn_dim_multiplier": 2,
+        "num_queries": 1,
+        "codebook_size": 4,
+        "beta": 0.25,
+    }]
+    model = HierarchicalAutoencoder(
+        num_levels=1,
+        compressor_level_configs=comp_cfg,
+        initial_vocab_size=259,
+        expander_dim_scale=1.0,
+        expander_num_enc_layers=1,
+        expander_num_dec_layers=1,
+        expander_heads_scale=1.0,
+        expander_eos_id=1,
+        expander_max_len=8,
+        propagate_key_padding_mask=True,
+        aux_lm_loss_weight=0.0,
+        top_transformer_config=None,
+        top_lm_loss_weight=0.0,
+    )
+    model.eval()
+    return model
+
+
+def test_patches_per_token_matches_ratio():
+    torch.manual_seed(0)
+    model = build_model()
+    tokens = torch.tensor([[2, 3, 4, 5]], dtype=torch.long)
+    kpm = torch.zeros_like(tokens, dtype=torch.bool)
+
+    out = model.forward(tokens, key_padding_mask=kpm)
+
+    tokens_total = (~kpm).sum().item()
+    output_len_total = out["output_seq_lengths_compressors"][0] * tokens.size(0)
+
+    tokens_per_second = tokens_total  # assume 1 second elapsed
+    patches_per_second = output_len_total
+
+    ratio_measured = patches_per_second / tokens_per_second
+    ratio_reported = out["compression_ratios"][0]
+    if isinstance(ratio_reported, torch.Tensor):
+        ratio_reported = ratio_reported.item()
+
+    assert abs(ratio_measured - ratio_reported) < 1e-5

--- a/train.py
+++ b/train.py
@@ -454,11 +454,15 @@ if __name__ == "__main__":
 
             if 'compression_ratios' in output_dict:
                 for level_idx, ratio in enumerate(output_dict['compression_ratios']):
-                    accumulators["compression_ratios"][level_idx] += ratio # Assuming ratio is already a float or .item() called
+                    # ratio is already a float or tensor scalar
+                    accumulators["compression_ratios"][level_idx] += ratio
+
+                batch_sz = tokens.size(0)
                 for level_idx, length in enumerate(output_dict['input_seq_lengths_compressors']):
-                    accumulators["input_seq_lengths_compressors"][level_idx] += length
+                    # lengths from the model are per-sample averages
+                    accumulators["input_seq_lengths_compressors"][level_idx] += length * batch_sz
                 for level_idx, length in enumerate(output_dict['output_seq_lengths_compressors']):
-                    accumulators["output_seq_lengths_compressors"][level_idx] += length
+                    accumulators["output_seq_lengths_compressors"][level_idx] += length * batch_sz
 
             if 'all_codebook_perplexities' in output_dict:
                 for level_idx, perplexity in enumerate(output_dict['all_codebook_perplexities']):


### PR DESCRIPTION
## Summary
- fix accumulation of patch counts in training loop
- add unit test for patch throughput ratio

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68713f1977fc832691f2427afa8c924b