### PR TITLE
Refactor save_base_components utility

### DIFF
--- a/components/__init__.py
+++ b/components/__init__.py
@@ -5,3 +5,4 @@ from .hierarchical_autoencoder import HierarchicalAutoencoder
 from .swiglu import SwiGLU
 from .expander import DecoderOnlyExpander
 from .tokenizer import ByteLevelTokenizer
+from .checkpoint_utils import save_base_components

--- a/components/checkpoint_utils.py
+++ b/components/checkpoint_utils.py
@@ -1,0 +1,29 @@
+"""Checkpoint utility functions."""
+
+from __future__ import annotations
+
+import os
+import torch
+
+from .hierarchical_autoencoder import HierarchicalAutoencoder
+
+
+def save_base_components(model: HierarchicalAutoencoder, path: str) -> None:
+    """Save only the compressor and expander weights from ``model``.
+
+    The resulting file can be used to initialize another model with pretrained
+    base components.
+
+    Args:
+        model: The :class:`HierarchicalAutoencoder` containing the components.
+        path: Destination file path.
+    """
+    os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+    torch.save(
+        {
+            "compressors": model.compressors.state_dict(),
+            "expanders": model.expanders.state_dict(),
+        },
+        path,
+    )
+    print(f"Base components saved to {path}")

--- a/tests/test_base_component_loading.py
+++ b/tests/test_base_component_loading.py
@@ -5,7 +5,7 @@ import torch
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from components.hierarchical_autoencoder import HierarchicalAutoencoder
-from train import save_base_components
+from components.checkpoint_utils import save_base_components
 
 
 def build_base_model():

--- a/train.py
+++ b/train.py
@@ -24,22 +24,13 @@ from components.sliding_window_attention import _cached_cross_window_mask as _ca
 from components.expander import _cached_causal_mask as _cached_causal_mask_cpu
 from components.utils import short_num, format_duration
 from components.tokenizer import ByteLevelTokenizer
+from components.checkpoint_utils import save_base_components
 from data_utils import tokenize_and_process_examples
 from configs.base_config import (
     DEVICE as DEFAULT_DEVICE,
     N_CPU as DEFAULT_N_CPU,
     ExpConfig,
 )
-
-
-def save_base_components(model: HierarchicalAutoencoder, path: str) -> None:
-    """Save only the compressor and expander weights."""
-    os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
-    torch.save({
-        "compressors": model.compressors.state_dict(),
-        "expanders": model.expanders.state_dict(),
-    }, path)
-    print(f"Base components saved to {path}")
 
 if __name__ == "__main__":
 


### PR DESCRIPTION
## Summary
- add `components/checkpoint_utils.py` to hold checkpoint helpers
- import and re-export `save_base_components`
- remove old implementation from `train.py`
- fix tests to import new module

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687150d2a3908326a20567a4b7e32377