### PR TITLE
Fix segmentation comment

### DIFF
--- a/components/byte_segment_compressor.py
+++ b/components/byte_segment_compressor.py
@@ -164,8 +164,9 @@ class ByteSegmentCompressor(nn.Module):
         # 2. Perform Entropy-Based Segmentation
         # This part determines segment boundaries based on token prediction entropy.
         # It's done with no_grad as the segmentation logic itself is not learned here.
+        # ``token_entropy`` computes entropy from the LM logits and ``entropy_segments``
+        # converts the resulting sequence of entropies into segment identifiers.
         with torch.no_grad():
-            # token_entropy and entropy_segments are assumed to be defined elsewhere
             entropy = token_entropy(logits)  # (B,S)
             seg_id = entropy_segments(
                 entropy,


### PR DESCRIPTION
## Summary
- clarify reference to `token_entropy` and `entropy_segments` in the byte segment compressor

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872c3310ec4832693187ff3e8ddd253