### PR TITLE
Clean up test imports

### DIFF
--- a/tests/test_base_component_loading.py
+++ b/tests/test_base_component_loading.py
@@ -1,8 +1,5 @@
-import os
-import sys
 import torch
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from components.hierarchical_autoencoder import HierarchicalAutoencoder
 from components.checkpoint_utils import save_base_components

--- a/tests/test_compression_loss.py
+++ b/tests/test_compression_loss.py
@@ -1,8 +1,5 @@
-import os
-import sys
 import torch
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from components.hierarchical_autoencoder import HierarchicalAutoencoder
 

--- a/tests/test_continuous_transformer.py
+++ b/tests/test_continuous_transformer.py
@@ -1,7 +1,4 @@
 import torch
-import os
-import sys
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from components.code_sequence_transformer import CodeSequenceTransformer
 from components.vector_quantizer import VectorQuantizer

--- a/tests/test_expander_continuous_training.py
+++ b/tests/test_expander_continuous_training.py
@@ -1,7 +1,4 @@
 import torch
-import os
-import sys
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from components.hierarchical_autoencoder import HierarchicalAutoencoder
 

--- a/tests/test_generation.py
+++ b/tests/test_generation.py
@@ -1,8 +1,5 @@
 import torch
-import os
-import sys
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from components.hierarchical_autoencoder import HierarchicalAutoencoder
 

--- a/tests/test_patch_throughput_ratio.py
+++ b/tests/test_patch_throughput_ratio.py
@@ -1,8 +1,5 @@
-import os
-import sys
 import torch
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from components.hierarchical_autoencoder import HierarchicalAutoencoder
 

--- a/tests/test_sliding_window_cross_attention.py
+++ b/tests/test_sliding_window_cross_attention.py
@@ -1,8 +1,5 @@
-import os
-import sys
 import torch
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from components.sliding_window_attention import SlidingWindowCrossAttention
 

--- a/tests/test_top_lm_cross_entropy.py
+++ b/tests/test_top_lm_cross_entropy.py
@@ -1,7 +1,4 @@
 import torch
-import os
-import sys
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from components.hierarchical_autoencoder import HierarchicalAutoencoder
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,9 +1,6 @@
-import os
-import sys
 import torch
 import pytest
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from components.utils import safe_softmax, token_entropy, entropy_segments
 

--- a/tests/test_vector_quantizer.py
+++ b/tests/test_vector_quantizer.py
@@ -1,8 +1,5 @@
 import torch
-import os
-import sys
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from components.vector_quantizer import VectorQuantizer
 
 def test_vector_quantizer_forward_no_ema():

--- a/tests/test_vq_reset_interval.py
+++ b/tests/test_vq_reset_interval.py
@@ -1,8 +1,5 @@
 import torch
-import os
-import sys
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from components.hierarchical_autoencoder import HierarchicalAutoencoder
 


### PR DESCRIPTION
## Summary
- drop redundant path hacks from tests
- add empty `tests/__init__` so pytest can find project modules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872d5574c94832699f33a028b80a58c