### PR TITLE
Add weighted MSE+CE top LM loss

### DIFF
--- a/configs/base_config.py
+++ b/configs/base_config.py
@@ -42,6 +42,8 @@ class TopTransformerConfig:
     num_heads: int = 12
     ffn_dim_multiplier: int = 4
     continuous: bool = True  # When False, the top LM predicts discrete codes using cross-entropy
+    mse_weight: float = 1.0  # Weight for the MSE component of the top LM loss
+    ce_weight: float = 1.0   # Weight for the cross-entropy component of the top LM loss
 
 
 @dataclass

--- a/tests/test_top_lm_cross_entropy.py
+++ b/tests/test_top_lm_cross_entropy.py
@@ -37,5 +37,7 @@ def test_top_lm_cross_entropy_loss():
     tokens = torch.tensor([[2, 3, 4, 5]], dtype=torch.long)
     kpm = torch.zeros_like(tokens, dtype=torch.bool)
     out = model.forward(tokens, key_padding_mask=kpm)
-    assert "top_code_ce" in out["top_code_lm_loss_details"]
+    details = out["top_code_lm_loss_details"]
+    assert "top_code_ce" in details
+    assert "top_code_mse" in details
 


### PR DESCRIPTION
## Summary
- allow configuring mse_weight and ce_weight in `TopTransformerConfig`
- store weights in hierarchical autoencoder
- combine cross entropy and MSE for the top code LM
- respect the `continuous` flag for transformer inputs during generation
- update cross entropy test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6877e0bd9b4c8326a5e1b1a9ac14782e