### PR TITLE
Expose LM loss component weights

### DIFF
--- a/components/hae_lm.py
+++ b/components/hae_lm.py
@@ -68,6 +68,8 @@ class HierarchicalAELM(LM):
             ),
             top_lm_loss_weight=exp_config.top_lm_loss_weight,
             use_continuous_expander_inputs=exp_config.use_continuous_expander_inputs,
+            top_lm_mse_weight=exp_config.top_lm_mse_weight,
+            top_lm_ce_weight=exp_config.top_lm_ce_weight,
         ).to(self.device)
         ckpt = torch.load(checkpoint, map_location=self.device)
         self.model.load_state_dict(ckpt["model_state"])

--- a/configs/base_config.py
+++ b/configs/base_config.py
@@ -65,6 +65,8 @@ class ExpConfig:
     propagate_key_padding_mask: bool = True
     aux_lm_loss_weight: float = 1.0
     top_lm_loss_weight: float = 1.0
+    top_lm_mse_weight: float = 1.0
+    top_lm_ce_weight: float = 1.0
     top_transformer_config: Optional[TopTransformerConfig] = field(
         default_factory=TopTransformerConfig
     )

--- a/train.py
+++ b/train.py
@@ -128,6 +128,8 @@ def initialize_model(
         ),
         top_lm_loss_weight=exp_config.top_lm_loss_weight,
         use_continuous_expander_inputs=exp_config.use_continuous_expander_inputs,
+        top_lm_mse_weight=exp_config.top_lm_mse_weight,
+        top_lm_ce_weight=exp_config.top_lm_ce_weight,
     ).to(device)
 
     if args.load_base_from:


### PR DESCRIPTION
## Summary
- add `top_lm_mse_weight` and `top_lm_ce_weight` to `ExpConfig`
- accept and propagate these weights in `HierarchicalAutoencoder`
- forward new config values when constructing models

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877e6f465a48326b07cb66c17e35ae1