### PR TITLE
Fix VQ resets when sampling with frozen base components

### DIFF
--- a/train.py
+++ b/train.py
@@ -624,6 +624,9 @@ def train_loop(
                         mlflow.log_text(mlflow_text_log, f"sample_generation_step_{global_step}.txt")
 
                     model.train()
+                    if args.load_base_from:
+                        model.compressors.eval()
+                        model.expanders.eval()
                 if global_step > 0 and global_step % exp_config.checkpoint_interval == 0:
                     save_checkpoint(
                         model,


### PR DESCRIPTION
## Summary
- keep compressors and expanders in `eval` mode after sample generation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68797a81b71c8326b9dedc9026022717