### PR TITLE
Fix --load_base_from checkpoint parsing

### DIFF
--- a/components/__init__.py
+++ b/components/__init__.py
@@ -6,5 +6,5 @@ from .byte_segment_compressor import ByteSegmentCompressor
 from .swiglu import SwiGLU
 from .expander import DecoderOnlyExpander
 from .tokenizer import ByteLevelTokenizer
-from .checkpoint_utils import save_base_components
+from .checkpoint_utils import save_base_components, load_base_components
 from .code_sequence_transformer import CodeSequenceTransformer


### PR DESCRIPTION
## Summary
- allow loading base components from checkpoints saved with either the old or new format
- expose `load_base_components` helper
- use the helper inside `train.py`
- extend tests for new checkpoint style

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68799636e8988326b7e5b54c2d7ce42f