### PR TITLE
Refactor expander config

### DIFF
--- a/components/hae_lm.py
+++ b/components/hae_lm.py
@@ -52,14 +52,14 @@ class HierarchicalAELM(LM):
             num_levels=exp_config.num_levels,
             compressor_level_configs=[asdict(c) for c in exp_config.compressor_level_configs],
             initial_vocab_size=exp_config.initial_vocab_size,
-            expander_dim_scale=exp_config.expander_dim_scale,
-            expander_num_enc_layers=exp_config.expander_num_enc_layers,
-            expander_num_dec_layers=exp_config.expander_num_dec_layers,
-            expander_heads_scale=exp_config.expander_heads_scale,
-            expander_eos_id=exp_config.expander_eos_id,
-            expander_max_len=exp_config.expander_max_len,
-            use_decoder_only_expander=exp_config.use_decoder_only_expander,
-            propagate_key_padding_mask=exp_config.propagate_key_padding_mask,
+            expander_dim_scale=exp_config.expander.dim_scale,
+            expander_num_enc_layers=exp_config.expander.num_enc_layers,
+            expander_num_dec_layers=exp_config.expander.num_dec_layers,
+            expander_heads_scale=exp_config.expander.heads_scale,
+            expander_eos_id=exp_config.expander.eos_id,
+            expander_max_len=exp_config.expander.max_len,
+            use_decoder_only_expander=exp_config.expander.use_decoder_only,
+            propagate_key_padding_mask=exp_config.expander.propagate_key_padding_mask,
             aux_lm_loss_weight=exp_config.aux_lm_loss_weight,
             top_transformer_config=(
                 asdict(exp_config.top_transformer_config)
@@ -67,7 +67,7 @@ class HierarchicalAELM(LM):
                 else None
             ),
             top_lm_loss_weight=exp_config.top_lm_loss_weight,
-            use_continuous_expander_inputs=exp_config.use_continuous_expander_inputs,
+            use_continuous_expander_inputs=exp_config.expander.use_continuous_inputs,
             top_lm_mse_weight=exp_config.top_lm_mse_weight,
             top_lm_ce_weight=exp_config.top_lm_ce_weight,
         ).to(self.device)
@@ -93,7 +93,7 @@ class HierarchicalAELM(LM):
 
     @property
     def max_length(self) -> int:
-        return self.exp_config.get("expander_max_len", 2048)
+        return getattr(self.exp_config.expander, "max_len", 2048)
 
     def _tokens_logprobs(self, tokens: torch.Tensor) -> torch.Tensor:
         with torch.no_grad():

--- a/configs/base_config.py
+++ b/configs/base_config.py
@@ -55,6 +55,19 @@ class TopTransformerConfig:
 
 
 @dataclass
+class ExpanderConfig:
+    dim_scale: float = 1.0
+    num_enc_layers: int = 2
+    num_dec_layers: int = 4
+    heads_scale: float = 1.0
+    eos_id: int = 1
+    max_len: int = 8192
+    use_decoder_only: bool = True
+    propagate_key_padding_mask: bool = True
+    use_continuous_inputs: bool = False
+
+
+@dataclass
 class ExpConfig:
     run_name: str = "HierarchicalAE_Default"
     project_name: str = "TemporalAutoencodedLanguageModelling"
@@ -63,14 +76,7 @@ class ExpConfig:
     compressor_level_configs: List[CompressorLevelConfig] = field(
         default_factory=lambda: [CompressorLevelConfig()]
     )
-    expander_dim_scale: float = 1.0
-    expander_num_enc_layers: int = 2
-    expander_num_dec_layers: int = 4
-    expander_heads_scale: float = 1.0
-    expander_eos_id: int = 1
-    expander_max_len: int = 8192
-    use_decoder_only_expander: bool = True
-    propagate_key_padding_mask: bool = True
+    expander: ExpanderConfig = field(default_factory=ExpanderConfig)
     aux_lm_loss_weight: float = 1.0
     top_lm_loss_weight: float = 1.0
     top_lm_mse_weight: float = 1.0
@@ -102,7 +108,6 @@ class ExpConfig:
     checkpoint_dir: str = "./checkpoints"
     resume_from_checkpoint: Optional[str] = None
     save_base_components_path: Optional[str] = None
-    use_continuous_expander_inputs: bool = False
     mlflow_batch_interval: int = 50
 
     def as_dict(self) -> Dict[str, Any]:

--- a/configs/stage1_super_tiny_config.py
+++ b/configs/stage1_super_tiny_config.py
@@ -27,8 +27,8 @@ exp_config.compressor_level_configs = [
         compression_loss_weight=1.0,
     )
 ]
-exp_config.expander_num_enc_layers = 1
-exp_config.expander_num_dec_layers = 1
+exp_config.expander.num_enc_layers = 1
+exp_config.expander.num_dec_layers = 1
 exp_config.aux_lm_loss_weight = 0.1
 exp_config.top_lm_loss_weight = 0.0
 exp_config.top_transformer_config = None

--- a/configs/stage2_super_tiny_config.py
+++ b/configs/stage2_super_tiny_config.py
@@ -28,8 +28,8 @@ exp_config.compressor_level_configs = [
         compression_loss_weight=1.0,
     )
 ]
-exp_config.expander_num_enc_layers = 1
-exp_config.expander_num_dec_layers = 1
+exp_config.expander.num_enc_layers = 1
+exp_config.expander.num_dec_layers = 1
 exp_config.aux_lm_loss_weight = 0.1
 exp_config.top_lm_loss_weight = 1.0
 exp_config.top_transformer_config = TopTransformerConfig(

--- a/configs/super_tiny_config.py
+++ b/configs/super_tiny_config.py
@@ -28,8 +28,8 @@ exp_config.compressor_level_configs = [
         compression_loss_weight=1.0,
     )
 ]
-exp_config.expander_num_enc_layers = 1
-exp_config.expander_num_dec_layers = 1
+exp_config.expander.num_enc_layers = 1
+exp_config.expander.num_dec_layers = 1
 exp_config.aux_lm_loss_weight = 0.1
 exp_config.top_lm_loss_weight = 1.0
 exp_config.top_transformer_config = TopTransformerConfig(

--- a/train.py
+++ b/train.py
@@ -112,14 +112,14 @@ def initialize_model(
         num_levels=exp_config.num_levels,
         compressor_level_configs=[asdict(c) for c in exp_config.compressor_level_configs],
         initial_vocab_size=exp_config.initial_vocab_size,
-        expander_dim_scale=exp_config.expander_dim_scale,
-        expander_num_enc_layers=exp_config.expander_num_enc_layers,
-        expander_num_dec_layers=exp_config.expander_num_dec_layers,
-        expander_heads_scale=exp_config.expander_heads_scale,
-        expander_eos_id=exp_config.expander_eos_id,
-        expander_max_len=exp_config.expander_max_len,
-        use_decoder_only_expander=exp_config.use_decoder_only_expander,
-        propagate_key_padding_mask=exp_config.propagate_key_padding_mask,
+        expander_dim_scale=exp_config.expander.dim_scale,
+        expander_num_enc_layers=exp_config.expander.num_enc_layers,
+        expander_num_dec_layers=exp_config.expander.num_dec_layers,
+        expander_heads_scale=exp_config.expander.heads_scale,
+        expander_eos_id=exp_config.expander.eos_id,
+        expander_max_len=exp_config.expander.max_len,
+        use_decoder_only_expander=exp_config.expander.use_decoder_only,
+        propagate_key_padding_mask=exp_config.expander.propagate_key_padding_mask,
         aux_lm_loss_weight=exp_config.aux_lm_loss_weight,
         top_transformer_config=(
             asdict(exp_config.top_transformer_config)
@@ -127,7 +127,7 @@ def initialize_model(
             else None
         ),
         top_lm_loss_weight=exp_config.top_lm_loss_weight,
-        use_continuous_expander_inputs=exp_config.use_continuous_expander_inputs,
+        use_continuous_expander_inputs=exp_config.expander.use_continuous_inputs,
         top_lm_mse_weight=exp_config.top_lm_mse_weight,
         top_lm_ce_weight=exp_config.top_lm_ce_weight,
     ).to(device)


### PR DESCRIPTION
## Summary
- add an `ExpanderConfig` dataclass that groups expander settings
- update usage of expander settings in training and inference code
- adjust configs to override the new dataclass fields

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68825a437b388326a252204d14c9826a