### PR TITLE
Fix compression ratio logging and CPU compatibility

### DIFF
--- a/components/expander.py
+++ b/components/expander.py
@@ -13,8 +13,9 @@ from .sliding_window_attention import SlidingWindowCrossAttention
 @lru_cache(maxsize=64)
 def _cached_causal_mask(length: int) -> torch.Tensor:
     """Return a causal mask computed on CPU."""
+    device = "cuda" if torch.cuda.is_available() else "cpu"
     mask = torch.triu(
-        torch.ones(length, length, device="cuda", dtype=torch.bool), diagonal=1
+        torch.ones(length, length, device=device, dtype=torch.bool), diagonal=1
     )
     return mask
 

--- a/components/hierarchical_autoencoder.py
+++ b/components/hierarchical_autoencoder.py
@@ -289,7 +289,9 @@ class HierarchicalAutoencoder(nn.Module):
             out_len / in_len if in_len > 0 else 0.0
             for in_len, out_len in zip(all_input_seq_lengths, all_output_seq_lengths)
         ]
-        compression_ratios = [tokens.new_tensor(r) for r in compression_ratios]
+        compression_ratios = [
+            tokens.new_tensor(r, dtype=torch.float32) for r in compression_ratios
+        ]
 
         return {
             'top_codes': all_codes_list[-1] if all_codes_list else torch.empty(0,

--- a/components/mla.py
+++ b/components/mla.py
@@ -100,8 +100,9 @@ class MultiheadLatentAttention(nn.Module):
         self.q_proj = nn.Linear(dim_q, self.h * self.k, bias=False)
 
         # absorbed projections to compressed spaces
-        self.w_kc_q = nn.Parameter(torch.empty(self.h, self.k, self.d_cq, device='cuda'))  # K→d_c'
-        self.w_kc_kv = nn.Parameter(torch.empty(self.h, self.k, self.d_c, device='cuda'))  # K→d_c
+        device = 'cuda' if torch.cuda.is_available() else 'cpu'
+        self.w_kc_q = nn.Parameter(torch.empty(self.h, self.k, self.d_cq, device=device))  # K→d_c'
+        self.w_kc_kv = nn.Parameter(torch.empty(self.h, self.k, self.d_c, device=device))  # K→d_c
 
         self.register_buffer(
             "w_kc_kv_T", self.w_kc_kv.transpose(1, 2), persistent=False
@@ -171,7 +172,7 @@ class MultiheadLatentAttention(nn.Module):
         # -- 2. user‑supplied bias / mask operates on raw logits ---------------
         scores = self.score_mod(scores)
 
-        # Apply sparse mask if given
+        mask = torch.zeros_like(scores, dtype=torch.bool)
         if block_mask is not None:
             if hasattr(block_mask, 'mask_mod'):
                 B, H, _, L = scores.shape
@@ -179,12 +180,13 @@ class MultiheadLatentAttention(nn.Module):
                 k_idx = q_idx[:, None]
                 keep = block_mask.mask_mod(0, 0, q_idx[:, None], k_idx[:, None])
                 scores = scores.masked_fill(keep, -float('inf'))
+                mask = mask | keep
             else:
                 scores = scores.masked_fill(block_mask, float('inf'))
-
+                mask = mask | block_mask
 
         # -- 3. softmax & value aggregation ------------------------------------
-        attn = safe_softmax(scores, dim=-1)  # [B, H, L]
+        attn = safe_softmax(scores, mask, dim=-1)  # [B, H, L]
 
         # fused gemm: (B·H)×L @ L×d_c  →  (B·H)×d_c
         return torch.matmul(attn, v_c)  # [B, H, d_c]

--- a/components/sliding_window_attention.py
+++ b/components/sliding_window_attention.py
@@ -16,8 +16,9 @@ from typing import Optional, Tuple
 @lru_cache(maxsize=64)
 def _cached_cross_window_mask(q_len: int, kv_len: int, window: int) -> torch.Tensor:
     """Return a cross-window mask computed on CPU."""
-    q_idx = torch.arange(q_len, device="cuda")[:, None]
-    kv_idx = torch.arange(kv_len, device="cuda")[None, :]
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    q_idx = torch.arange(q_len, device=device)[:, None]
+    kv_idx = torch.arange(kv_len, device=device)[None, :]
     rel_pos = kv_idx - q_idx
     mask = (rel_pos > 0) | (rel_pos < -window)
     return mask


### PR DESCRIPTION
## Summary
- ensure compression ratios use floating dtypes
- make MultiheadLatentAttention and sliding-window attention CPU friendly
- fix fallback attention masking and safe_softmax call
- adjust causal mask device handling
- update tests

## Testing
- `pytest -q tests/test_compression_loss.py::test_forward_reports_compression_loss`
- `pytest -q tests/test_patch_throughput_ratio.py::test_patches_per_token_matches_ratio`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68842c46aae48326a8a97bcd84e9406f