### PR TITLE
Fix MSE scaling with embedding width

### DIFF
--- a/components/hierarchical_autoencoder.py
+++ b/components/hierarchical_autoencoder.py
@@ -504,7 +504,7 @@ class HierarchicalAutoencoder(nn.Module):
                 mask = kpm_for_top_codes[:, 1:] if kpm_for_top_codes is not None else None
 
                 target_cont = cont[:, 1:, :]
-                mse_per_tok = F.mse_loss(pred, target_cont, reduction='none').sum(dim=-1)
+                mse_per_tok = F.mse_loss(pred, target_cont, reduction='none').mean(dim=-1)
 
                 target_codes = codes[:, 1:]
                 codebook = self.compressors[-1].vq.codebook


### PR DESCRIPTION
## Summary
- avoid growing top code LM loss with embedding dimension by averaging MSE across features

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6887a5f583c48326b431d7141dd6b96e