### PR TITLE
Switch attention mask to tensor

### DIFF
--- a/components/learned_query_attention.py
+++ b/components/learned_query_attention.py
@@ -1,7 +1,6 @@
 import torch
 import torch.nn as nn
-import torch.nn.functional as F # Required if safe_softmax uses F.softmax
-from typing import Optional, Tuple, Callable, Union
+from typing import Optional, Tuple
 import math
 
 from .utils import safe_softmax
@@ -86,7 +85,7 @@ class LearnedQueryAttention(nn.Module):
         self,
         x: torch.Tensor,                            # Input context: (B, S, D) for keys & values
         queries: torch.Tensor,                      # Pre-built queries: (B, Q_tot, D)
-        attn_mask: Union[torch.Tensor, Callable],   # Attention mask: (B*H, Q_tot, S), boolean (True where masked)
+        attn_mask: torch.Tensor,                    # Attention mask: (B*H, Q_tot, S), boolean (True where masked)
         key_padding_mask: Optional[torch.Tensor] = None # Key padding mask: (B, S), boolean (True where padded)
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         """
@@ -148,27 +147,9 @@ class LearnedQueryAttention(nn.Module):
         scores = (q @ k) / math.sqrt(self.head_dim)
 
         # scores: (B,H,Q,S)
-        if callable(attn_mask):
-            # Build mask *on the fly* by giving indices to the closure
-            q_idx = torch.arange(Q_tot, device=scores.device)[:, None]             # (Q,)
-            k_idx = torch.arange(S,     device=scores.device)[None, :]             # (S,)
-            # (B,Q,S) — stack calls for each batch
-            mask_bqs = torch.stack(
-                [attn_mask(b=i, h=0, q_idx=q_idx, k_idx=k_idx) for i in range(B)],
-                dim=0
-            )
-            combined_mask = mask_bqs.unsqueeze(1)  # (1,1,Q,S)
-            if key_padding_mask is not None:
-                combined_mask = combined_mask | key_padding_mask[:, None, None, :]
-        else:
-            # Combine attention mask and key padding mask
-            # Reshape attn_mask from (B*H, Q_tot, S) to (B, H, Q_tot, S) for broadcasting
-            combined_mask = attn_mask.view(B, self.num_heads, Q_tot, S)
-            if key_padding_mask is not None:
-                # Expand key_padding_mask from (B, S) to (B, 1, 1, S) for broadcasting.
-                # If a key is padded (True in key_padding_mask), or if attn_mask
-                # already specifies masking (True in combined_mask), then mask.
-                combined_mask = combined_mask | key_padding_mask[:, None, None, :] # (B,H,Q,S)
+        combined_mask = attn_mask.view(B, self.num_heads, Q_tot, S)
+        if key_padding_mask is not None:
+            combined_mask = combined_mask | key_padding_mask[:, None, None, :]  # (B,H,Q,S)
 
         # Apply softmax with the combined mask
         # `safe_softmax` is assumed to handle masking by setting masked scores to -inf before softmax


### PR DESCRIPTION
## Summary
- remove callable mask logic from `LearnedQueryAttention`
- build segment mask tensors directly in `ByteSegmentCompressor`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688cffa89d888326adf7087011768e5d